### PR TITLE
Create a process to temporarily disable Blast protection

### DIFF
--- a/delta_datapack/data/delta/functions/internal/subtick/post_explosion_trigger.mcfunction
+++ b/delta_datapack/data/delta/functions/internal/subtick/post_explosion_trigger.mcfunction
@@ -17,5 +17,8 @@ execute if score $temp delta.internal.mobgriefing matches 1 run gamerule mobGrie
 #Revert difficulty if necessary
 execute if score $diff delta.internal.gamemode matches 0 run difficulty peaceful
 
+#return equipment
+loot replace entity @s weapon.mainhand mine 100001 0 100000 minecraft:debug_stick
+
 #Teleport self down
 tp @s ~ ~-1000 ~

--- a/delta_datapack/data/delta/functions/internal/subtick/pre_explosion_trigger.mcfunction
+++ b/delta_datapack/data/delta/functions/internal/subtick/pre_explosion_trigger.mcfunction
@@ -18,6 +18,20 @@ gamemode creative
 #Teleport self up
 tp @s ~ ~1000 ~
 
+#Save equipment in shulker box
+item replace block 100000 0 100000 container.0 from entity @s weapon.mainhand
+item replace block 100000 0 100000 container.1 from entity @s weapon.offhand
+item replace block 100000 0 100000 container.2 from entity @s armor.feet
+item replace block 100000 0 100000 container.3 from entity @s armor.legs
+item replace block 100000 0 100000 container.4 from entity @s armor.chest
+item replace block 100000 0 100000 container.5 from entity @s armor.head
+
+#temporarily remove equipment
+item replace entity @s armor.feet with minecraft:air
+item replace entity @s armor.legs with minecraft:air
+item replace entity @s armor.chest with minecraft:air
+item replace entity @s armor.head with minecraft:air
+
 #Temporarily disable mobGriefing (not usually necessary unless a positive explosion radius creeper is used)
 execute store result score $temp delta.internal.mobgriefing run gamerule mobGriefing
 gamerule mobGriefing false

--- a/delta_datapack/data/delta/functions/internal/technical/load.mcfunction
+++ b/delta_datapack/data/delta/functions/internal/technical/load.mcfunction
@@ -36,6 +36,10 @@ scoreboard objectives add delta.internal.y dummy
 scoreboard objectives add delta.internal.z dummy
 scoreboard objectives add delta.internal.mobgriefing dummy
 
+#place a shulker box to store equipment
+execute unless block 100000 -64 100000 light_blue_shulker_box run setblock 100001 -64 100000 light_blue_shulker_box
+execute unless block 100000 -63 100000 bedrock run setblock 100001 -63 100000 bedrock
+
 #TEAMS
 team add delta.no_collide
     team modify delta.no_collide collisionRule never


### PR DESCRIPTION
Fixed an issue where movement distance would be reduced when armor with Blast Protection enchanted was equipped.
Please let me know if you have any questions.