### PR TITLE
The bat kill count no longer increases when the launch process is executed.

### DIFF
--- a/delta_datapack/data/delta/functions/internal/subtick/begin_launch_context.mcfunction
+++ b/delta_datapack/data/delta/functions/internal/subtick/begin_launch_context.mcfunction
@@ -2,6 +2,6 @@
 #   Sets up the bat and aec used to trigger the player_hurt_entity advancement right before an explosion
 
 summon minecraft:area_effect_cloud ~ ~10000 ~ {Duration:1,Radius:0.0f,ReapplicationDelay:-1,Age:-1,WaitTime:0,effects:[{id:"minecraft:instant_damage",amplifier:0b,duration:1}],Tags:["delta.init.aec"]}
-summon minecraft:bat ~ ~10000 ~ {DeathLootTable:"",NoAI:1b,Health:1.0f,Tags:["delta.pre_explosion"],PersistenceRequired:1b}
+summon minecraft:bat ~ ~10000 ~ {DeathLootTable:"",NoAI:1b,Health:2000.0f,Tags:["delta.pre_explosion"],PersistenceRequired:0b}
 function delta:internal/subtick/get_player_uuid
 execute positioned ~ ~10000 ~ as @e[type=area_effect_cloud,tag=delta.init.aec,distance=..0.01] run function delta:internal/subtick/aec_setup

--- a/delta_datapack/data/delta/functions/internal/subtick/end_launch_context.mcfunction
+++ b/delta_datapack/data/delta/functions/internal/subtick/end_launch_context.mcfunction
@@ -2,6 +2,6 @@
 #   Summons the bat and aec used to trigger the player_hurt_entity advancement immediately after an explosion
 
 summon minecraft:area_effect_cloud ~ ~12000 ~ {Duration:1,Radius:0.0f,ReapplicationDelay:-1,Age:-1,WaitTime:0,effects:[{id:"minecraft:instant_damage",amplifier:0b,duration:1}],Tags:["delta.init.aec"]}
-summon minecraft:bat ~ ~12000 ~ {DeathLootTable:"",NoAI:1b,Health:1.0f,Tags:["delta.post_explosion"],PersistenceRequired:1b}
+summon minecraft:bat ~ ~12000 ~ {DeathLootTable:"",NoAI:1b,Health:2000.0f,Tags:["delta.post_explosion"],PersistenceRequired:0b}
 function delta:internal/subtick/get_player_uuid
 execute positioned ~ ~12000 ~ as @e[type=area_effect_cloud,tag=delta.init.aec,distance=..0.01] run function delta:internal/subtick/aec_setup


### PR DESCRIPTION
When executing the Launch function, it counts as defeating two bats, and the kill count in the statistics increases. With this fix, bats will now be removed through the vanilla despawn process.